### PR TITLE
update Sample code to handle control-C and cleanly shutdown the Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 /.idea/
 /target/
+*.html
+type*
+*.js
+resources/*
+jquery/*
+element-list
+stylesheet.css
+*.zip

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ application with parameters that reset the chip and then enables bus 2.
  parameter -b 0x01 value assumes the chip is connected to raspberry I2C bus 1,
  and the chip is operating at default address -a 0x70.
 
+If you are debugging a problemL:  Execute your code with the -f parm 0. After
+your execution the log file /tmp/logs/com.pi4j.devices.tca9548.Tca9548.log
+will contain its maximum detail, this can be used to debug your error.
 
 Classes:
 com.pi4j.devices.base_i2c.BasicI2cDevice  Simple layer between TCA9548 and the

--- a/com-pi4j-devices.iml
+++ b/com-pi4j-devices.iml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_11">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:2.0.0-alpha0" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-simple:2.0.0-alpha0" level="project" />
+    <orderEntry type="library" name="Maven: com.pi4j:pi4j-core:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.13.3" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-core:2.13.3" level="project" />
+    <orderEntry type="library" name="Maven: com.pi4j:pi4j-plugin-raspberrypi:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: com.pi4j:pi4j-plugin-pigpio:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: com.pi4j:pi4j-library-pigpio:2.0-SNAPSHOT" level="project" />
+  </component>
+</module>

--- a/src/main/java/com/pi4j/devices/base_util/ffdc/FfdcLoggingModule.java
+++ b/src/main/java/com/pi4j/devices/base_util/ffdc/FfdcLoggingModule.java
@@ -45,4 +45,7 @@ public interface FfdcLoggingModule {
     void ffdcErrorExit(String detail, int code);
 
     boolean ffdcClearLogs(String detail);
+
+    boolean ffdcFlushShutdown();
+
 }

--- a/src/main/java/com/pi4j/devices/base_util/ffdc/FfdcUtil.java
+++ b/src/main/java/com/pi4j/devices/base_util/ffdc/FfdcUtil.java
@@ -139,6 +139,12 @@ public class FfdcUtil implements FfdcLoggingModule, FfdcLoggingSystem {
         return (true);
     }
 
+    @Override
+    public boolean ffdcFlushShutdown() {
+        LogManager.shutdown();
+        return(true);
+    }
+
 
     @Override
     public void printLoadedPlatforms() {

--- a/src/main/java/com/pi4j/devices/tca9548/Tca9548.java
+++ b/src/main/java/com/pi4j/devices/tca9548/Tca9548.java
@@ -304,4 +304,5 @@ public class Tca9548 extends BasicI2cDevice implements GpioBasics {
     }
 
 
+
 }


### PR DESCRIPTION
A couple documentation changes and CTl-C handler added.  So cleanup code for the logging server.

When I complete the java docs I have a large drop for the MCP23008 and MCP23017 GPIO controller.  Includes some utilities for interrupt monitoring and auto configuring the path if thru a mux/switch