### PR TITLE
update log4j to use apache fix.  and use pi4j 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
         <!-- DEPENDENCIES VERSIONS -->
         <slf4j.version>2.0.0-alpha0</slf4j.version>
-        <pi4j.version>2.1.0-SNAPSHOT</pi4j.version>
+        <pi4j.version>2.2.0-SNAPSHOT</pi4j.version>
 
         <!-- BUILD PLUGIN VERSIONS -->
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
@@ -106,12 +106,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
         </dependency>
         <!-- include Pi4J Plugins (Platforms and I/O Providers) -->
         <dependency>


### PR DESCRIPTION
Security hole in log4j apache code.  Moved dependency to the version  containing the fix.  Also moved pi4j to version 2.2.0