### PR TITLE
Adjust examples to the driver release cleanup

### DIFF
--- a/src/main/java/com/pi4j/examples/games/bricks/Bricks.java
+++ b/src/main/java/com/pi4j/examples/games/bricks/Bricks.java
@@ -1,5 +1,7 @@
 package com.pi4j.examples.games.bricks;
 
+import com.pi4j.drivers.display.graphics.Argb32;
+import com.pi4j.drivers.display.graphics.Graphics;
 import com.pi4j.drivers.display.graphics.GraphicsDisplay;
 import com.pi4j.drivers.input.GameController;
 import com.pi4j.io.ListenableOnOffRead;
@@ -18,6 +20,7 @@ public class Bricks {
     private static final int PADDLE_Y = FIELD_SIZE - PADDLE_HEIGHT * 3 / 2;
 
     private final GraphicsDisplay display;
+    private final Graphics graphics;
     private final GameController controller;
     private final Delay delay = new Delay();
     private final Map<ListenableOnOffRead<?>, Consumer<Boolean>> keys = new HashMap<>();
@@ -44,6 +47,7 @@ public class Bricks {
     public Bricks(GraphicsDisplay display, GameController controller) {
         this.display = display;
         this.controller = controller;
+        this.graphics = display.getGraphics();
         int displayWidth = display.getWidth();
         int displayHeight = display.getHeight();
 
@@ -78,8 +82,10 @@ public class Bricks {
     }
 
     private void initializeBricks() {
-        display.fillRect(0, 0, display.getWidth(), display.getHeight(), 0xffffffff);
-        display.fillRect(x0, y0, scale * FIELD_SIZE, scale * FIELD_SIZE, 0xff000000);
+        graphics.setColor(Argb32.WHITE);
+        graphics.fillRect(0, 0, display.getWidth(), display.getHeight());
+        graphics.setColor(Argb32.BLACK);
+        graphics.fillRect(x0, y0, scale * FIELD_SIZE, scale * FIELD_SIZE);
         for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 3; j++) {
                 setBrick(i, j, true);
@@ -163,11 +169,13 @@ public class Bricks {
     }
 
     private void renderPaddle(boolean on) {
-        display.fillRect(x0 + paddleX * scale, y0 + PADDLE_Y * scale,  PADDLE_WIDTH * scale, PADDLE_HEIGHT * scale, on ? 0x888888 : 0);
+        graphics.setColor(on ? 0xff888888 : Argb32.BLACK);
+        graphics.fillRect(x0 + paddleX * scale, y0 + PADDLE_Y * scale,  PADDLE_WIDTH * scale, PADDLE_HEIGHT * scale);
     }
 
     private void renderBall(boolean on) {
-        display.fillRect(Math.round(x0 + ballX * scale), y0 + ballY * scale, BALL_SIZE * scale , BALL_SIZE * scale, on ? 0x888888 : 0);
+        graphics.setColor(on ? 0xff888888 : Argb32.BLACK);
+        graphics.fillRect(Math.round(x0 + ballX * scale), y0 + ballY * scale, BALL_SIZE * scale , BALL_SIZE * scale);
     }
 
 
@@ -199,11 +207,11 @@ public class Bricks {
 
     private void setBrick(int x, int y, boolean alive) {
         bricks[x][y] = alive;
-        display.fillRect(
+        graphics.setColor(alive ? (y == 0 ? 0xffff8888 : y == 1 ? 0xffff8888 : 0xff88ff88) : 0);
+        graphics.fillRect(
             x0 + 16 * x * scale + 1,
             y0 + 8 * (y + 1) * scale + 1,
             14 * scale,
-            6 * scale,
-            alive ? (y == 0 ? 0xffff8888 : y == 1 ? 0xffff8888 : 0xff88ff88) : 0);
+            6 * scale);
     }
 }

--- a/src/main/java/com/pi4j/examples/games/snake/Snake.java
+++ b/src/main/java/com/pi4j/examples/games/snake/Snake.java
@@ -1,6 +1,8 @@
 package com.pi4j.examples.games.snake;
 
+import com.pi4j.drivers.display.graphics.Argb32;
 import com.pi4j.drivers.display.graphics.GraphicsDisplay;
+import com.pi4j.drivers.display.graphics.Graphics;
 import com.pi4j.drivers.input.GameController;
 import com.pi4j.io.ListenableOnOffRead;
 import com.pi4j.util.Delay;
@@ -23,6 +25,7 @@ public class Snake {
     private static final int FADE_OUT_TIME = 2000;
 
     private final GraphicsDisplay display;
+    private final Graphics graphics;
     private final GameController controller;
     private final Delay delay = new Delay();
     private final int x0;
@@ -47,6 +50,7 @@ public class Snake {
     public Snake(GraphicsDisplay display, GameController controller) {
         this.display = display;
         this.controller = controller;
+        this.graphics = display.getGraphics();
 
         int displayWidth = display.getWidth();
         int displayHeight = display.getHeight();
@@ -79,8 +83,10 @@ public class Snake {
 
     private void initialize() {
         arena = new Entity[AREA_SIZE][AREA_SIZE];
-        display.fillRect(0, 0, display.getWidth(), display.getHeight(), 0xffffffff);
-        display.fillRect(x0, y0, scale * AREA_SIZE, scale * AREA_SIZE, 0xff000000);
+        graphics.setColor(Argb32.WHITE);
+        graphics.fillRect(0, 0, display.getWidth(), display.getHeight());
+        graphics.setColor(Argb32.BLACK);
+        graphics.fillRect(x0, y0, scale * AREA_SIZE, scale * AREA_SIZE);
         body.clear();
         length = 1;
 
@@ -96,7 +102,8 @@ public class Snake {
     }
 
     private void renderColor(int x, int y, int color) {
-        display.fillRect(x0 + x * scale, y0 + y * scale, scale, scale, color);
+        graphics.setColor(color);
+        graphics.fillRect(x0 + x * scale, y0 + y * scale, scale, scale);
     }
 
     public void run() {
@@ -117,7 +124,8 @@ public class Snake {
             step();
             delay.materialize();;
         }
-        display.fillRect(0, 0, display.getWidth(), display.getHeight(), 0xff000000);
+        graphics.setColor(Argb32.BLACK);
+        graphics.fillRect(0, 0, display.getWidth(), display.getHeight());
         for (Map.Entry<ListenableOnOffRead<?>, Consumer<Boolean>> entry : keys.entrySet()) {
             entry.getKey().removeConsumer(entry.getValue());
         }

--- a/src/main/java/com/pi4j/examples/hat/DisplayHatDemo.java
+++ b/src/main/java/com/pi4j/examples/hat/DisplayHatDemo.java
@@ -6,7 +6,6 @@ import com.pi4j.drivers.display.graphics.GraphicsDisplay;
 import com.pi4j.drivers.input.GameController;
 import com.pi4j.drivers.input.KeyPad;
 import com.pi4j.drivers.sensor.Sensor;
-import com.pi4j.drivers.sound.Note;
 import com.pi4j.drivers.sound.SoundDriver;
 import com.pi4j.examples.apps.calculator.Calculator;
 import com.pi4j.examples.games.bricks.Bricks;
@@ -63,7 +62,7 @@ public class DisplayHatDemo {
         }
         if (soundDriver != null) {
             menu.add("Play Demo Sound", () -> {
-                soundDriver.playNotes(103, null, Note.G4, 8, Note.G4, 8, Note.G4, 8, Note.DS4, 6, Note.AS4, 2, Note.G4, 8, Note.DS4, 6, Note.AS4, 2, Note.G4, 16);
+                soundDriver.playNotes("o2l4t120 cdefg2g2 aaaag2 aaaag2 ffffe2e2 ddddc1");
             });
         }
         menu.add("Exit", ListView.EXIT_ACTION);

--- a/src/main/java/com/pi4j/examples/hat/elecrow/crowpi2/CrowPi2Demo.java
+++ b/src/main/java/com/pi4j/examples/hat/elecrow/crowpi2/CrowPi2Demo.java
@@ -2,7 +2,7 @@ package com.pi4j.examples.hat.elecrow.crowpi2;
 
 import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
-import com.pi4j.drivers.hat.elecrow.CrowPi2;
+import com.pi4j.drivers.incubator.hat.elecrow.CrowPi2;
 import com.pi4j.examples.hat.DisplayHatDemo;
 
 public class CrowPi2Demo {

--- a/src/main/java/com/pi4j/examples/sensor/autodetect/Autodetect.java
+++ b/src/main/java/com/pi4j/examples/sensor/autodetect/Autodetect.java
@@ -29,7 +29,7 @@ public class Autodetect {
 
             List<SensorDescriptor.Value> valueDescriptors = sensor.getDescriptor().getValues();
 
-            float[] values = new float[valueDescriptors.size()];
+            double[] values = new double[valueDescriptors.size()];
             sensor.readMeasurement(values);
 
             for (SensorDescriptor.Value valueDescriptor : valueDescriptors) {

--- a/src/main/java/com/pi4j/examples/server/SensorServer.java
+++ b/src/main/java/com/pi4j/examples/server/SensorServer.java
@@ -80,7 +80,7 @@ public class SensorServer {
         for (Sensor sensor : sensorList) {
             SensorDescriptor descriptor = sensor.getDescriptor();
             List<SensorDescriptor.Value> valueDescriptors = descriptor.getValues();
-            float[] measurements = new float[valueDescriptors.size()];
+            double[] measurements = new double[valueDescriptors.size()];
             sensor.readMeasurement(measurements);
             for (SensorDescriptor.Value valueDescriptor : valueDescriptors) {
                 sb.append(first ? "\n  " : ",\n  ");
@@ -105,7 +105,7 @@ public class SensorServer {
         for (Sensor sensor : sensorList) {
             SensorDescriptor descriptor = sensor.getDescriptor();
             List<SensorDescriptor.Value> valueDescriptors = descriptor.getValues();
-            float[] measurements = new float[valueDescriptors.size()];
+            double[] measurements = new double[valueDescriptors.size()];
             sensor.readMeasurement(measurements);
             for (SensorDescriptor.Value valueDescriptor : valueDescriptors) {
                 String name = getUniqueName(names, valueDescriptor);

--- a/src/main/java/com/pi4j/examples/ui/SensorView.java
+++ b/src/main/java/com/pi4j/examples/ui/SensorView.java
@@ -71,7 +71,7 @@ public class SensorView {
                 public void run() {
                     int listIndex = 0;
                     for (Sensor sensor : sensors) {
-                        float[] values = new float[sensor.getDescriptor().getValues().size()];
+                        double[] values = new double[sensor.getDescriptor().getValues().size()];
                         sensor.readMeasurement(values);
                         for (SensorDescriptor.Value valueDescriptor : sensor.getDescriptor().getValues()) {
                             listView.set(listIndex, titleCase(valueDescriptor.getKind().name()) + ": " + Math.round(100 * values[valueDescriptor.getIndex()]) / 100f);


### PR DESCRIPTION
Was a bit more than expected:

- Examples were still using GraphicsDisplay instead of Graphics for drawing
- Examples were also still using float arrays instead of doubles for sensor values
- One example was using a removed sound call
- The CrowPi example needed adjustment to the incubator package