### PR TITLE
mcp3008 example use new subclass Mcp3008Driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>com.pi4j</groupId>
             <artifactId>pi4j-drivers</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/src/main/java/com/pi4j/devices/mcp3008/MCP3008App.java
+++ b/src/main/java/com/pi4j/devices/mcp3008/MCP3008App.java
@@ -4,7 +4,7 @@ package com.pi4j.devices.mcp3008;
 
 import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
-import com.pi4j.drivers.io.ad.mcp300x.Mcp300xDriver;
+import com.pi4j.drivers.io.ad.mcp300x.Mcp3008Driver;
 import com.pi4j.io.exception.IOException;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiBus;
@@ -86,13 +86,14 @@ public class MCP3008App {
             .mode(SpiMode.MODE_0)
             .build();
         Spi spi = pi4j.create(spiConfig);
-        Mcp300xDriver mcpDrv = new com.pi4j.drivers.io.ad.mcp300x.Mcp300xDriver(spi) ;
+        Mcp3008Driver mcpDrv = new com.pi4j.drivers.io.ad.mcp300x.Mcp3008Driver(spi) ;
 
         int val;
         if(doAll){
             for ( short c = 0; c < 8 ; c++){
                 val = mcpDrv.readChannel(c);
                 getConversionValue(c, val, vref, console);
+                Thread.sleep(150      );
             }
         }else {
             val = mcpDrv.readChannel(pinNumber);

--- a/src/main/java/com/pi4j/devices/vl53L0X/README.md
+++ b/src/main/java/com/pi4j/devices/vl53L0X/README.md
@@ -40,10 +40,6 @@ The program defaults to the device being connected to Pi i2c bus 1, and ACKs dev
 
 At power on the chip is configured to 0x29 device address, default parm values will operate correctly.
 
-Config the i2c mux
-
-sudo ./runTca9548.sh -b 0x01 -a 0x70 -f 1 -l -e 0x2 -r 0x13
-
 sudo ./runVL53L0X.sh
 
 The user can reconfigure the chips device (ACK) address


### PR DESCRIPTION
Chnage to use new subclass for mcp3008 driver.  Also add delay when repeatedly requesting data via the SPI.  Immediate transfers occasional return garbage data.  